### PR TITLE
Remove private modifier from Medium

### DIFF
--- a/src/main/scala/com/snowplowanalytics/refererparser/Medium.scala
+++ b/src/main/scala/com/snowplowanalytics/refererparser/Medium.scala
@@ -18,9 +18,9 @@ package com.snowplowanalytics.refererparser
 /**
  * Enumeration for supported mediums.
  */
-private[refererparser] sealed abstract class Medium(val value: String)
+sealed abstract class Medium(val value: String)
 
-private[refererparser] object Medium {
+object Medium {
   def fromString(s: String): Option[Medium] = s match {
     case UnknownMedium.value   => Some(UnknownMedium)
     case SearchMedium.value    => Some(SearchMedium)
@@ -39,9 +39,9 @@ private[refererparser] object Medium {
   val Paid = PaidMedium
 }
 
-private[refererparser] final case object UnknownMedium extends Medium("unknown")
-private[refererparser] final case object SearchMedium extends Medium("search")
-private[refererparser] final case object InternalMedium extends Medium("internal")
-private[refererparser] final case object SocialMedium extends Medium("social")
-private[refererparser] final case object EmailMedium extends Medium("email")
-private[refererparser] final case object PaidMedium extends Medium("paid")
+case object UnknownMedium extends Medium("unknown")
+case object SearchMedium extends Medium("search")
+case object InternalMedium extends Medium("internal")
+case object SocialMedium extends Medium("social")
+case object EmailMedium extends Medium("email")
+case object PaidMedium extends Medium("paid")


### PR DESCRIPTION
<!--
Thank you for contributing to the Scala-Java referer-parser library!

You'll find a small checklist below which should help speed up the
review processs:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow-referer-parser/jvm-referer-parser/blob/develop/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `develop` branch?
-->

As discussed in #47, this PR makes the `Medium` enumeration publicly accessible. 