### PR TITLE
Update referrer list in 0.3.0 (closes #75)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "2.0.1"
+maxColumn = 120

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+Version 0.3.1 (2019-09-19)
+--------------------------
+Update scala to 2.11.1 and sbt to 0.13.18
+Update referers.yml to latest version from https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.yml
+Read referrer config file (DB) from S3 containing latest list of referrers (https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.yml) with fallback to referrers hardcoded in referer.yml
+Paid section added to referrer list
+
 Version 0.3.0 (2015-09-02)
 --------------------------
 Added Taboola, Outbrain and other referers (#109)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,19 +1,18 @@
 /**
- * Copyright 2012-2013 Snowplow Analytics Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+  * Copyright 2012-2013 Snowplow Analytics Ltd
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 import sbt._
 import Keys._
 
@@ -21,13 +20,13 @@ object BuildSettings {
 
   // Basic settings for our app
   lazy val basicSettings = Seq[Setting[_]](
-    organization  := "com.snowplowanalytics",
-    version       := "0.3.0",
-    description   := "Library for extracting marketing attribution data from referer URLs",
-    scalaVersion  := "2.9.1",
+    organization := "com.snowplowanalytics",
+    version := "0.3.1",
+    description := "Library for extracting marketing attribution data from referer URLs",
+    scalaVersion := "2.11.1",
     crossScalaVersions := Seq("2.9.1", "2.10.4", "2.11.1"),
     scalacOptions := Seq("-deprecation", "-encoding", "utf8"),
-    resolvers     ++= Dependencies.resolutionRepos
+    resolvers ++= Dependencies.resolutionRepos
   )
 
   // Publish settings
@@ -35,12 +34,13 @@ object BuildSettings {
   lazy val publishSettings = Seq[Setting[_]](
     // Enables publishing to maven repo
     publishMavenStyle := true,
-
     publishTo <<= version { version =>
       val basePath = "target/repo/%s".format {
         if (version.trim.endsWith("SNAPSHOT")) "snapshots/" else "releases/"
       }
-      Some(Resolver.file("Local Maven repository", file(basePath)) transactional())
+      Some(
+        Resolver.file("Local Maven repository", file(basePath)) transactional ()
+      )
     }
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,19 +1,18 @@
 /**
- * Copyright 2012-2013 Snowplow Analytics Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+  * Copyright 2012-2013 Snowplow Analytics Ltd
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 import sbt._
 import Keys._
 
@@ -23,42 +22,55 @@ object Dependencies {
   )
 
   object V {
-    val yaml       = "1.10"
-    val http       = "4.3.3"
+    val yaml = "1.10"
+    val http = "4.3.3"
     object specs2 {
-      val _29   = "1.12.1"
-      val _210  = "1.14"
-      val _211  = "2.3.13"
+      val _29  = "1.12.1"
+      val _210 = "1.14"
+      val _211 = "2.3.13"
     }
-    val scalaCheck = "1.10.0"
-    val scalaUtil  = "0.1.0"
-    val junit      = "4.11"
-    val json       = "20140107"
-    val json4s     = "3.2.9"
+    val scalaCheck   = "1.10.0"
+    val scalaUtil    = "0.1.0"
+    val junit        = "4.11"
+    val json         = "20140107"
+    val json4s       = "3.2.9"
+    val logback      = "1.2.3"
+    val scalaLogging = "3.9.2"
   }
 
   object Libraries {
-    val yaml          = "org.yaml"                   %  "snakeyaml"            % V.yaml
-    val httpClient    = "org.apache.httpcomponents"  %  "httpclient"           % V.http
+    val yaml             = "org.yaml"                   % "snakeyaml"       % V.yaml
+    val httpClient       = "org.apache.httpcomponents"  % "httpclient"      % V.http
+    val httpFluentClient = "org.apache.httpcomponents"  % "fluent-hc"       % V.http
+    val logback          = "ch.qos.logback"             % "logback-classic" % V.logback
+    val scalaLogging     = "com.typesafe.scala-logging" %% "scala-logging"  % V.scalaLogging
     object specs2 {
-      val _29   = "org.specs2"                 %% "specs2"               % V.specs2._29        % "test"
-      val _210  = "org.specs2"                 %% "specs2"               % V.specs2._210       % "test"
-      val _211  = "org.specs2"                 %% "specs2"               % V.specs2._211       % "test"
+      val _29  = "org.specs2" %% "specs2" % V.specs2._29  % "test"
+      val _210 = "org.specs2" %% "specs2" % V.specs2._210 % "test"
+      val _211 = "org.specs2" %% "specs2" % V.specs2._211 % "test"
     }
-    val junit         = "junit"                      % "junit"                 % V.junit       % "test"
-    val json          = "org.json"                   % "json"                  % V.json        % "test"
-    val scalaCheck    = "org.scalacheck"             %% "scalacheck"           % V.scalaCheck  % "test"
-    val scalaUtil     = "com.snowplowanalytics"      %  "scala-util"           % V.scalaUtil   % "test"
-    val json4sJackson = "org.json4s"                %% "json4s-jackson"        % V.json4s      % "test"
-    val json4sScalaz  = "org.json4s"                %% "json4s-scalaz"         % V.json4s      % "test"
+    val junit         = "junit"                 % "junit"           % V.junit      % "test"
+    val json          = "org.json"              % "json"            % V.json       % "test"
+    val scalaCheck    = "org.scalacheck"        %% "scalacheck"     % V.scalaCheck % "test"
+    val scalaUtil     = "com.snowplowanalytics" % "scala-util"      % V.scalaUtil  % "test"
+    val json4sJackson = "org.json4s"            %% "json4s-jackson" % V.json4s     % "test"
+    val json4sScalaz  = "org.json4s"            %% "json4s-scalaz"  % V.json4s     % "test"
   }
 
-  def onVersion[A](all: Seq[A] = Seq(), on29: => Seq[A] = Seq(), on210: => Seq[A] = Seq(), on211: => Seq[A] = Seq()) =
-    scalaVersion(v => all ++ (if (v.contains("2.9.")) {
-      on29
-    } else if (v.contains("2.10.")) {
-      on210
-    } else {
-      on211
-    }))
+  def onVersion[A](
+      all: Seq[A] = Seq(),
+      on29: => Seq[A] = Seq(),
+      on210: => Seq[A] = Seq(),
+      on211: => Seq[A] = Seq()
+  ) =
+    scalaVersion(
+      v =>
+        all ++ (if (v.contains("2.9.")) {
+                  on29
+                } else if (v.contains("2.10.")) {
+                  on210
+                } else {
+                  on211
+                })
+    )
 }

--- a/project/RefererParserBuild.scala
+++ b/project/RefererParserBuild.scala
@@ -1,19 +1,18 @@
 /**
- * Copyright 2012-2013 Snowplow Analytics Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+  * Copyright 2012-2013 Snowplow Analytics Ltd
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 import sbt._
 import Keys._
 
@@ -24,7 +23,9 @@ object RefererParserBuild extends Build {
 
   // Configure prompt to show current project
   override lazy val settings = super.settings :+ {
-    shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
+    shellPrompt := { s =>
+      Project.extract(s).currentProject.id + " > "
+    }
   }
 
   // Define our project, with basic project information and library dependencies
@@ -35,11 +36,15 @@ object RefererParserBuild extends Build {
         all = Seq(
           Libraries.yaml,
           Libraries.httpClient,
+          Libraries.httpFluentClient,
+          Libraries.logback,
+          Libraries.scalaLogging,
           Libraries.scalaCheck,
           Libraries.scalaUtil,
           Libraries.junit,
           Libraries.json,
-          Libraries.json4sJackson),
+          Libraries.json4sJackson
+        ),
         on29 = Seq(Libraries.specs2._29),
         on210 = Seq(Libraries.specs2._210),
         on211 = Seq(Libraries.specs2._211)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.18

--- a/src/main/java/com/snowplowanalytics/refererparser/Medium.java
+++ b/src/main/java/com/snowplowanalytics/refererparser/Medium.java
@@ -28,7 +28,8 @@ public enum Medium {
     INTERNAL,
     SEARCH,
     SOCIAL,
-    EMAIL;
+    EMAIL,
+    PAID;
 
   static public Medium fromString(String medium) {
     return Medium.valueOf(medium.toUpperCase());

--- a/src/main/resources/referers.yml
+++ b/src/main/resources/referers.yml
@@ -8,6 +8,7 @@
 # 2. Email providers
 # 3. Social providers
 # 4. Search providers
+# 5. Paid media
 
 
 # #######################################################################################################
@@ -29,7 +30,6 @@ unknown:
       - sites.google.com
       - groups.google.com
       - groups.google.co.uk
-      - news.google.co.uk
 
   Yahoo!:
     domains:
@@ -51,14 +51,6 @@ unknown:
       - omg.yahoo.com
       - match.yahoo.net
 
-  Taboola:
-    domains:
-      - trc.taboola.com
-      - api.taboola.com
-
-  Outbrain:
-    domains:
-      - paid.outbrain.com
 
 
 # #######################################################################################################
@@ -75,6 +67,14 @@ email:
     domains:
       - mail.163.com
 
+  2degrees:
+    domains:
+      - webmail.2degreesbroadband.co.nz
+
+  Adam Internet:
+    domains:
+      - webmail.adam.com.au
+
   AOL Mail:
     domains:
       - mail.aol.com
@@ -83,22 +83,60 @@ email:
     domains:
       - webmail.bigpond.com
       - webmail2.bigpond.com
+      - email.telstra.com
+      - basic.messaging.bigpond.com
+
+  Commander:
+    domains:
+      - webmail.commander.net.au
 
   Daum Mail:
     domains:
       - mail2.daum.net
+      - mail.daum.net
+
+  Dodo:
+    domains:
+      - webmail.dodo.com.au
+
+  Freenet:
+    domains:
+      - webmail.freenet.de
 
   Gmail:
     domains:
       - mail.google.com
+      - inbox.google.com
+
+  iiNet:
+    domains:
+      - webmail.iinet.net.au
+      - mail.iinet.net.au
+
+  Inbox.com:
+    domains:
+      - inbox.com
+
+  iPrimus:
+    domains:
+      - webmail.iprimus.com.au
+
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
   Naver Mail:
     domains:
       - mail.naver.com
 
+  Netspace:
+    domains:
+      - webmail.netspace.net.au
+
   Optus Zoo:
     domains:
-      - webmail.optuszoo.com.au  
+      - webmail.optuszoo.com.au
+      - webmail.optusnet.com.au
 
   Orange Webmail:
     domains:
@@ -107,6 +145,7 @@ email:
   Outlook.com:
     domains:
       - mail.live.com
+      - outlook.live.com
 
   QQ Mail:
     domains:
@@ -114,7 +153,19 @@ email:
 
   Seznam Mail:
     domains:
-      - email.seznam.cz  
+      - email.seznam.cz
+
+  Virgin:
+    domains:
+      - webmail.virginbroadband.com.au
+
+  Vodafone:
+    domains:
+      - webmail.vodafone.co.nz
+
+  Westnet:
+    domains:
+      - webmail.westnet.com.au
 
   Yahoo! Mail:
     domains:
@@ -122,11 +173,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
-      
-  Mynet Mail:
-    domains:
-      - mail.mynet.com
 
+  Zoho:
+    domains:
+      - mail.zoho.com
 
 # #######################################################################################################
 #
@@ -350,6 +400,7 @@ social:
   Tumblr:
     domains:
       - tumblr.com
+      - t.umblr.com
 
   Nasza-klasa.pl:
     domains:
@@ -373,7 +424,7 @@ social:
 
   Buzznet:
     domains:
-      - wayn.com
+      - buzznet.com
 
   Multiply:
     domains:
@@ -420,34 +471,34 @@ social:
     domains:
       - getpocket.com
       
-    ITU Sozluk:
+  ITU Sozluk:
     domains:
       - itusozluk.com
-      
+
   Instela:
     domains:
       - instela.com
-      
+
   Eksi Sozluk:
     domains:
       - Sozluk.com
       - sourtimes.org
-  
+
   Uludag Sozluk:
     domains:
       - uludagsozluk.com
       - ulusozluk.com
-  
+
   Inci Sozluk:
     domains:
       - inci.sozlukspot.com
       - incisozluk.com
       - incisozluk.cc
-  
+
   Hocam.com:
     domains:
       - hocam.com
-      
+
   Donanimhaber:
     domains:
       - donanimhaber.com 
@@ -462,6 +513,10 @@ social:
     domains:
       - quora.com
 
+    Whirlpool:
+      domains:
+        - forums.whirlpool.net.au
+
 # #######################################################################################################
 #
 # SEARCH PROVIDERS
@@ -475,6 +530,12 @@ search:
       - 1.cz
 
   # 123people TODO
+
+  1&1:
+    parameters:
+      - q
+    domains:
+      - search.1and1.com
 
   1und1:
     parameters:
@@ -575,6 +636,7 @@ search:
       - www.aolimages.aol.fr
       - aim.search.aol.com
       - www.recherche.aol.fr
+      - recherche.aol.fr
       - find.web.aol.com
       - recherche.aol.ca
       - aolsearch.aol.co.uk
@@ -696,6 +758,7 @@ search:
       - tieba.baidu.com
       - news.baidu.com
       - web.gougou.com
+      - m.baidu.com
 
   Biglobe:
     parameters:
@@ -747,6 +810,12 @@ search:
     domains:
       - search.bluewin.ch
 
+  British Telecommunications:
+    parameters:
+      - p
+    domains:
+      - search.bt.com
+
   canoe.ca:
     parameters:
       - q
@@ -777,12 +846,6 @@ search:
       - question
     domains:
       - pesquisa.clix.pt
-
-  Comcast:
-    parameters:
-      - q
-    domains:
-      - search.comcast.net
 
   Conduit:
     parameters:
@@ -870,6 +933,12 @@ search:
       - dmoz.org
       - editors.dmoz.org
 
+  Dodo:
+    parameters:
+      - q
+    domains:
+      - google.dodo.com.au
+
   DuckDuckGo:
     parameters:
       - q
@@ -951,6 +1020,12 @@ search:
       - name
     domains:
       - recherche.francite.com
+
+  Finderoo:
+    parameters:
+      - q
+    domains:
+      - www.finderoo.com
 
   Findwide:
     parameters:
@@ -1181,7 +1256,6 @@ search:
       - www.google.jo
       - www.google.co.jp
       - www.google.co.ke
-      - www.google.com.kh
       - www.google.ki
       - www.google.kg
       - www.google.co.kr
@@ -1262,6 +1336,7 @@ search:
       - www.google.tm
       - www.google.to
       - www.google.com.tn
+      - www.google.tn
       - www.google.com.tr
       - www.google.tt
       - www.google.com.tw
@@ -1378,7 +1453,6 @@ search:
       - google.jo
       - google.co.jp
       - google.co.ke
-      - google.com.kh
       - google.ki
       - google.kg
       - google.co.kr
@@ -1480,6 +1554,7 @@ search:
       - google.co.za
       - google.co.zm
       - google.co.zw
+      - google.tn
       # powered by Google
       - search.avg.com
       - isearch.avg.com
@@ -1591,7 +1666,6 @@ search:
       - blogsearch.google.com.gt
       - blogsearch.google.com.hk
       - blogsearch.google.com.jm
-      - blogsearch.google.com.kh
       - blogsearch.google.com.kh
       - blogsearch.google.com.kw
       - blogsearch.google.com.lb
@@ -1990,7 +2064,6 @@ search:
       - images.google.com.hk
       - images.google.com.jm
       - images.google.com.kh
-      - images.google.com.kh
       - images.google.com.kw
       - images.google.com.lb
       - images.google.com.lc
@@ -2110,7 +2183,6 @@ search:
       - images.google.us
       - images.google.vg
       - images.google.vu
-      - images.google.ws
 
   Google News:
     parameters:
@@ -2191,7 +2263,6 @@ search:
       - news.google.com.gt
       - news.google.com.hk
       - news.google.com.jm
-      - news.google.com.kh
       - news.google.com.kh
       - news.google.com.kw
       - news.google.com.lb
@@ -2394,7 +2465,6 @@ search:
       - google.com.hk/products
       - google.com.jm/products
       - google.com.kh/products
-      - google.com.kh/products
       - google.com.kw/products
       - google.com.lb/products
       - google.com.lc/products
@@ -2591,7 +2661,6 @@ search:
       - www.google.com.hk/products
       - www.google.com.jm/products
       - www.google.com.kh/products
-      - www.google.com.kh/products
       - www.google.com.kw/products
       - www.google.com.lb/products
       - www.google.com.lc/products
@@ -2782,6 +2851,12 @@ search:
     domains:
       - www.ilse.nl
 
+  Inbox.com:
+    parameters:
+      - q
+    domains:
+      - inbox.com/search/
+
   InfoSpace:
     parameters:
       - q
@@ -2801,6 +2876,13 @@ search:
       - search.searchcompletion.com
       - clusty.com
 
+  Flyingbird:
+    parameters:
+      - q
+    domains:
+      - inspsearch.com
+      - viview.inspsearch.com
+
   Interia:
     parameters:
       - q
@@ -2812,6 +2894,12 @@ search:
       - q
     domains:
       - start.iplay.com
+
+  I.ua:
+    parameters:
+      - q
+    domains:
+      - search.i.ua
 
   IXquick:
     parameters:
@@ -2861,6 +2949,12 @@ search:
       - q
     domains:
       - www.kvasir.no
+
+  kununu:
+    parameters:
+      - q
+    domains:
+      - kununu.com
 
   Latne:
     parameters:
@@ -3069,9 +3163,11 @@ search:
   Orange:
     parameters:
       - q
+      - kw
     domains:
       - busca.orange.es
       - search.orange.co.uk
+      - lemoteur.orange.fr   
 
   Paperball:
     parameters:
@@ -3101,7 +3197,7 @@ search:
     parameters:
       - q
     domains:
-      - www.plazoo.com
+      - poisk.ru
 
   PriceRunner:
     parameters:
@@ -3158,6 +3254,12 @@ search:
 
   # Add Scour.com
 
+  Search This:
+    parameters:
+      - q
+    domains:
+      - www.searchthis.com
+
   Search.com:
     parameters:
       - q
@@ -3208,11 +3310,20 @@ search:
     domains:
       - www.skynet.be
 
+  The Smart Search:
+    parameters:
+      - q
+    domains:
+      - thesmartsearch.net
+      - www.thesmartsearch.net
+
   Sogou:
     parameters:
       - query
+      - w
     domains:
       - www.sougou.com
+      - www.soso.com
 
   Softonic:
     parameters:
@@ -3220,11 +3331,12 @@ search:
     domains:
       - search.softonic.com
 
-  soso.com:
+  SoSoDesk:
     parameters:
-      - w
+      - q
     domains:
-      - www.soso.com
+      - sosodesktop.com
+      - search.sosodesktop.com
 
   Snapdo:
     parameters:
@@ -3273,6 +3385,12 @@ search:
       - q
     domains:
       - technorati.com
+
+  Telstra:
+    parameters:
+      - find
+    domains:
+      - search.media.telstra.com.au
 
   Teoma:
     parameters:
@@ -3336,11 +3454,23 @@ search:
     domains:
       - www.trusted--search.com
 
+  Tut.by:
+    parameters:
+      - query
+    domains:
+      - search.tut.by
+
   Twingly:
     parameters:
       - q
     domains:
       - www.twingly.com
+
+  UKR.net:
+    parameters:
+      - q
+    domains:
+      - search.ukr.net
 
   uol.com.br:
     parameters:
@@ -3481,8 +3611,6 @@ search:
       - es.search.yahoo.com
       - es.yahoo.com
       - espanol.searchpanol.yahoo.com
-      - espanol.searchpanol.yahoo.com
-      - espanol.yahoo.com
       - espanol.yahoo.com
       - fr.search.yahoo.com
       - fr.yahoo.com
@@ -3501,15 +3629,10 @@ search:
       - one.cn.yahoo.com
       - one.searchn.yahoo.com
       - qc.search.yahoo.com
-      - qc.search.yahoo.com
-      - qc.search.yahoo.com
       - qc.yahoo.com
-      - qc.yahoo.com
-      - se.search.yahoo.com
       - se.search.yahoo.com
       - se.yahoo.com
       - search.searcharch.yahoo.com
-      - search.yahoo.com
       - uk.search.yahoo.com
       - uk.yahoo.com
       - www.yahoo.co.jp
@@ -3619,3 +3742,178 @@ search:
       - q
     domains:
       - zoohoo.cz
+
+
+
+# #######################################################################################################
+#
+# PAID MEDIA
+
+paid:
+
+  Acuity Ads:
+    domains:
+      - acuityplatform.com
+
+  Adform:
+    domains:
+      - adform.net
+
+  AdRoll:
+    domains:
+      - adroll.com
+
+  AppNexus:
+    domains:
+      - ib.adnxs.com
+      - adnxs.com
+      - 247realmedia.com
+
+  AudienceScience:
+    domains:
+      - wunderloop.net
+
+  BidSwitch:
+    domains:
+      - bidswitch.net
+
+  Casale Media:
+    domains:
+      - casalemedia.com
+
+  Criteo:
+    domains:
+      - cas.jp.as.criteo.com
+      - cas.criteo.com
+
+  Doubleclick:
+    domains:
+      - ad.doubleclick.net
+      - ad-apac.doubleclick.net
+      - s0.2mdn.net
+      - s1.2mdn.net
+      - dp.g.doubleclick.net
+      - pubads.g.doubleclick.net
+
+  Eyeota:
+    domains:
+      - eyeota.net
+
+  Flashtalking:
+    domains:
+      - flashtalking.com
+      - servedby.flashtalking.com
+
+  Fluct:
+    domains:
+      - adingo.jp
+
+  Google:
+    domains:
+      - www.googleadservices.com
+      - partner.googleadservices.com
+      - googleads.g.doubleclick.net
+      - tpc.googlesyndication.com
+      - googleadservices.com
+      - imasdk.googleapis.com
+
+  LifeStreet:
+    domains:
+      - lfstmedia.com
+
+  Jivox:
+    domains:
+      - jivox.com
+
+  MicroAd:
+    domains:
+      - microad.jp
+
+  Mixpo:
+    domains:
+      - mixpo.com
+
+  Mozo:
+    domains:
+      - mozo.com.au
+      - a.mozo.com.au
+
+  Neustar AdAdvisor:
+    domains:
+      - adadvisor.net
+
+  ONE by AOL:
+    domains:
+      - nexage.com
+
+  OpenX:
+    domains:
+      - us-ads.openx.net
+      - openx.net
+      - servedbyopenx.com
+      - openxenterprise.com
+
+  Outbrain:
+    domains:
+      - paid.outbrain.com
+
+  Plista:
+    domains:
+      - farm.plista.com
+
+  PubMatic:
+    domains:
+      - sshowads.pubmatic.com
+
+  Rubicon Project:
+    domains:
+      - optimized-by.rubiconproject.com
+
+  Sizmek:
+    domains:
+      - bs.serving-sys.com
+
+  Sociomantic Labs:
+    domains:
+      - sociomantic.com
+
+  Sonobi:
+    domains:
+      - sonobi.com
+
+  Sovrn:
+    domains:
+      - lijit.com
+
+  SteelHouse:
+    domains:
+      - steelhousemedia.com
+
+  StickyADS.tv:
+    domains:
+      - stickyadstv.com
+      - sfx.stickyadstv.com
+
+  Taboola:
+    domains:
+      - trc.taboola.com
+      - api.taboola.com
+      - taboola.com
+
+  Tribal Fusion:
+    domains:
+      - cdnx.tribalfusion.com
+
+  White Pages:
+    domains:
+      - www.whitepages.com.au
+      - mobile.whitepages.com.au
+
+  Yieldmo:
+    domains:
+      - yieldmo.com
+
+  ZEDO:
+    domains:
+      - zedo.com
+      - z1.zedo.com

--- a/src/main/scala/com/snowplowanalytics/refererparser/scala/Parser.scala
+++ b/src/main/scala/com/snowplowanalytics/refererparser/scala/Parser.scala
@@ -1,77 +1,117 @@
 /**
- * Copyright 2012-2013 Snowplow Analytics Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+  * Copyright 2012-2013 Snowplow Analytics Ltd
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package com.snowplowanalytics.refererparser.scala
 
 // Java
+import java.io.ByteArrayInputStream
 import java.net.{URI, URISyntaxException}
+
+import scala.util.Failure
 
 // RefererParser Java impl
 import com.snowplowanalytics.refererparser.{Parser => JParser}
 import com.snowplowanalytics.refererparser.{Medium => JMedium}
 
 // Scala
-import scala.collection.JavaConversions._ 
+import scala.collection.JavaConversions._
+import scala.util.Try
+import com.typesafe.scalalogging.Logger
 
 /**
- * Enumeration for supported mediums.
- *
- * Replacement for Java version's Enum.
- */
+  * Enumeration for supported mediums.
+  *
+  * Replacement for Java version's Enum.
+  */
 object Medium extends Enumeration {
   type Medium = Value
 
-  val Unknown  = Value("unknown")
-  val Search   = Value("search")
+  val Unknown = Value("unknown")
+  val Search = Value("search")
   val Internal = Value("internal")
-  val Social   = Value("social")
-  val Email    = Value("email")
+  val Social = Value("social")
+  val Email = Value("email")
+  val Paid = Value("paid")
 
   /**
-   * Converts from our Java Medium Enum
-   * to our Scala Enumeration values above.
-   */
+    * Converts from our Java Medium Enum
+    * to our Scala Enumeration values above.
+    */
   def fromJava(medium: JMedium) =
     Medium.withName(medium.toString())
 }
 
 /**
- * Immutable case class to hold a referer.
- *
- * Replacement for Java version's POJO.
- */
+  * Immutable case class to hold a referer.
+  *
+  * Replacement for Java version's POJO.
+  */
 case class Referer(
-  medium: Medium.Medium,
-  source: Option[String],
-  term:   Option[String]
+    medium: Medium.Medium,
+    source: Option[String],
+    term: Option[String]
 )
 
 /**
- * Parser object - contains one-time initialization
- * of the YAML database of referers, and parse()
- * methods to generate a Referer object from a
- * referer URL.
- *
- * In Java this had to be instantiated as a class.
- */
+  * Parser object - contains one-time initialization
+  * of the YAML database of referers, and parse()
+  * methods to generate a Referer object from a
+  * referer URL.
+  *
+  * In Java this had to be instantiated as a class.
+  */
 object Parser {
 
   type MaybeReferer = Option[Referer]
 
-  private lazy val jp = new JParser()
+  val logger = Logger[Parser.type]
+
+  private lazy val jp: JParser = createParser
+
+  val createParser: JParser = {
+    import org.apache.http.client.fluent.Request
+    import org.apache.http.util.EntityUtils
+
+    val LatestReferrerUrl =
+      "https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.yml"
+
+    lazy val latestParser =
+      for {
+        _ <- Try(logger.info(s"Trying to load referrers from $LatestReferrerUrl"))
+        response <- Try(Request.Get(LatestReferrerUrl).execute().returnResponse())
+        statusCode <- Try(response.getStatusLine.getStatusCode)
+        if statusCode == 200
+        inStream <- Try(new ByteArrayInputStream(EntityUtils.toByteArray(response.getEntity)))
+        parser <- Try(new JParser(inStream))
+      } yield parser
+
+    latestParser.transform({ p =>
+      logger.info("Latest referrers loaded successfully")
+      Try(p)
+    }, { e =>
+      logger.warn(s"Errors: ${e.getMessage}")
+      Failure(e)
+    })
+
+    lazy val hardcodedParser = {
+      logger.warn("Falling back to hardcoded referrers")
+      new JParser()
+    }
+
+    latestParser.getOrElse(hardcodedParser)
+  }
 
   private def getHostSafely(uri: URI): String = {
     if (uri == null) {
@@ -82,46 +122,58 @@ object Parser {
   }
 
   /**
-   * Parses a `refererUri` UR and a `pageUri`
-   * URI to return either Some Referer, or None.
-   */
+    * Parses a `refererUri` UR and a `pageUri`
+    * URI to return either Some Referer, or None.
+    */
   def parse(refererUri: URI, pageUri: URI): MaybeReferer =
     parse(refererUri, getHostSafely(pageUri), Nil);
 
   /**
-   * Parses a `refererUri` UR and a `pageUri`
-   * URI to return either Some Referer, or None.
-   */
-  def parse(refererUri: URI, pageUri: URI, internalDomains: List[String]): MaybeReferer =
+    * Parses a `refererUri` UR and a `pageUri`
+    * URI to return either Some Referer, or None.
+    */
+  def parse(
+      refererUri: URI,
+      pageUri: URI,
+      internalDomains: List[String]
+  ): MaybeReferer =
     parse(refererUri, getHostSafely(pageUri), internalDomains);
 
   /**
-   * Parses a `refererUri` String and a `pageUri`
-   * URI to return either Some Referer, or None.
-   */
+    * Parses a `refererUri` String and a `pageUri`
+    * URI to return either Some Referer, or None.
+    */
   def parse(refererUri: String, pageUri: URI): MaybeReferer =
     parse(refererUri, getHostSafely(pageUri), Nil);
 
   /**
-   * Parses a `refererUri` String and a `pageUri`
-   * URI to return either Some Referer, or None.
-   */
-  def parse(refererUri: String, pageUri: URI, internalDomains: List[String]): MaybeReferer =
+    * Parses a `refererUri` String and a `pageUri`
+    * URI to return either Some Referer, or None.
+    */
+  def parse(
+      refererUri: String,
+      pageUri: URI,
+      internalDomains: List[String]
+  ): MaybeReferer =
     parse(refererUri, getHostSafely(pageUri), internalDomains);
 
   /**
-   * Parses a `refererUri` String and a `pageUri`
-   * URI to return either some Referer, or None.
-   */
+    * Parses a `refererUri` String and a `pageUri`
+    * URI to return either some Referer, or None.
+    */
   def parse(refererUri: String, pageHost: String): MaybeReferer = {
     parse(refererUri, pageHost, Nil)
   }
 
   /**
-   * Parses a `refererUri` String and a `pageUri`
-   * URI to return either some Referer, or None.
-   */
-  def parse(refererUri: String, pageHost: String, internalDomains: List[String]): MaybeReferer = {
+    * Parses a `refererUri` String and a `pageUri`
+    * URI to return either some Referer, or None.
+    */
+  def parse(
+      refererUri: String,
+      pageHost: String,
+      internalDomains: List[String]
+  ): MaybeReferer = {
 
     if (refererUri == null || refererUri == "") {
       None
@@ -135,24 +187,32 @@ object Parser {
   }
 
   /**
-   * Parses a `refererUri` URI to return
-   * either Some Referer, or None.
-   */
+    * Parses a `refererUri` URI to return
+    * either Some Referer, or None.
+    */
   def parse(refererUri: URI, pageHost: String): MaybeReferer = {
     parse(refererUri, pageHost, Nil)
-}
-
+  }
 
   /**
-   * Parses a `refererUri` URI to return
-   * either Some Referer, or None.
-   */
-  def parse(refererUri: URI, pageHost: String, internalDomains: List[String]): MaybeReferer = {
-    
+    * Parses a `refererUri` URI to return
+    * either Some Referer, or None.
+    */
+  def parse(
+      refererUri: URI,
+      pageHost: String,
+      internalDomains: List[String]
+  ): MaybeReferer = {
+
     try {
       val jrefr = Option(jp.parse(refererUri, pageHost, internalDomains))
-      jrefr.map(jr =>
-        Referer(Medium.fromJava(jr.medium), Option(jr.source), Option(jr.term))
+      jrefr.map(
+        jr =>
+          Referer(
+            Medium.fromJava(jr.medium),
+            Option(jr.source),
+            Option(jr.term)
+          )
       )
     } catch {
       case use: URISyntaxException => None


### PR DESCRIPTION
There was no tag for `0.3.0`, so I created one and forked branch `maintenance-0.3.0` as a "master" for changes that goes only into `0.3.0`. 
The url should be in config, but I haven't found any in that project, so I skipped it. This should be removed all together soon, when we will use `0.6.0`.