### PR TITLE
Add capability to identify referer with utm_source

### DIFF
--- a/src/main/scala/com/snowplowanalytics/refererparser/ParseReferers.scala
+++ b/src/main/scala/com/snowplowanalytics/refererparser/ParseReferers.scala
@@ -15,29 +15,42 @@ package com.snowplowanalytics.refererparser
 
 import cats.implicits._
 import io.circe._
-import io.circe.generic.semiauto._
 import io.circe.parser._
 
 /** Handles loading and storing referers */
 object ParseReferers {
   private final case class JsonEntry(
     domains: List[String],
-    parameters: Option[List[String]]
+    parameters: Option[List[String]],
+    utmSources: Option[List[String]]
   )
 
-  implicit private val jsonEntryDecoder: Decoder[JsonEntry] = deriveDecoder[JsonEntry]
+  // Using a manual decoder to avoid importing circe-generic-extras with Configuration.default.withSnakeCaseMemberNames
+  implicit private val jsonEntryDecoder: Decoder[JsonEntry] = Decoder.instance { c =>
+    for {
+      domains <- c.get[List[String]]("domains")
+      parameters <- c.get[Option[List[String]]]("parameters")
+      utmSources <- c.get[Option[List[String]]]("utm_sources")
+    } yield JsonEntry(domains, parameters, utmSources)
+  }
 
-  private[refererparser] def loadJsonFromString(rawJson: String): Either[Exception, Map[String, RefererLookup]] =
+  private[refererparser] def loadJsonFromString(rawJson: String): Either[Exception, ParsedReferers] =
     parse(rawJson).flatMap(loadJson)
 
-  def loadJson(doc: Json): Either[Exception, Map[String, RefererLookup]] =
+  def loadJson(doc: Json): Either[Exception, ParsedReferers] =
     parseReferersJson(doc.hcursor).map { parsed =>
-      parsed.foldLeft(Map.empty[String, RefererLookup]) { (map, mediumEntries) =>
+      parsed.foldLeft(ParsedReferers.empty) { (acc, mediumEntries) =>
         val (medium, entries) = mediumEntries
-        entries.foldLeft(map) { (mapInner, sourceEntry) =>
+        entries.foldLeft(acc) { (accInner, sourceEntry) =>
           val (source, entry) = sourceEntry
-          mapInner ++ entry.domains
-            .map(domain => domain -> RefererLookup(medium, source, entry.parameters.getOrElse(Nil)))
+          val lookup          = RefererLookup(medium, source, entry.parameters.getOrElse(Nil))
+          // The two indexes are built independently from the same entry: `byDomain` powers referer
+          // URI parsing, `byUtmSource` powers injected utm_source classification. Keeping them
+          // separate means a source's utm_sources are captured regardless of its domains.
+          ParsedReferers(
+            byDomain    = accInner.byDomain ++ entry.domains.map(_ -> lookup),
+            byUtmSource = accInner.byUtmSource ++ entry.utmSources.getOrElse(Nil).map(_ -> lookup)
+          )
         }
       }
     }

--- a/src/main/scala/com/snowplowanalytics/refererparser/ParsedReferers.scala
+++ b/src/main/scala/com/snowplowanalytics/refererparser/ParsedReferers.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2012-present Snowplow Analytics Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.snowplowanalytics.refererparser
+
+/**
+ * A parsed referer database, split into two independent lookup indexes:
+ *   - `byDomain`: referer host (+ optional path) -> referer, used when parsing a Referer URI
+ *   - `byUtmSource`: injected `utm_source` value -> referer, used to classify query parameters
+ *
+ * The two are built directly from the referer entries rather than one being derived from the other,
+ * so `utm_sources` are never tied to the presence of `domains`.
+ */
+final case class ParsedReferers(
+  byDomain: Map[String, RefererLookup],
+  byUtmSource: Map[String, RefererLookup]
+)
+
+object ParsedReferers {
+  val empty: ParsedReferers = ParsedReferers(Map.empty, Map.empty)
+
+  /** Build from a domain-keyed map only (no utm_source entries). */
+  def fromDomainMap(byDomain: Map[String, RefererLookup]): ParsedReferers =
+    ParsedReferers(byDomain, Map.empty)
+}

--- a/src/main/scala/com/snowplowanalytics/refererparser/Parser.scala
+++ b/src/main/scala/com/snowplowanalytics/refererparser/Parser.scala
@@ -24,7 +24,7 @@ import cats.syntax.functor._
 import scala.collection.compat.immutable.LazyList
 
 trait CreateParser[F[_]] {
-  def create(filePath: String, referers: Map[String, RefererLookup] = Map.empty): F[Either[Exception, Parser]]
+  def create(filePath: String, referers: ParsedReferers = ParsedReferers.empty): F[Either[Exception, Parser]]
 }
 
 object CreateParser {
@@ -32,7 +32,7 @@ object CreateParser {
 
   implicit def syncCreateParser[F[_]: Sync]: CreateParser[F] =
     new CreateParser[F] {
-      def create(filePath: String, referers: Map[String, RefererLookup]): F[Either[Exception, Parser]] =
+      def create(filePath: String, referers: ParsedReferers): F[Either[Exception, Parser]] =
         Resource
           .make(Sync[F].blocking(Source.fromFile(filePath)))(s => Sync[F].blocking(s.close()))
           .use(s => Sync[F].blocking(s.mkString))
@@ -42,7 +42,7 @@ object CreateParser {
 
   implicit def evalCreateParser: CreateParser[Eval] =
     new CreateParser[Eval] {
-      def create(filePath: String, referers: Map[String, RefererLookup]): Eval[Either[Exception, Parser]] =
+      def create(filePath: String, referers: ParsedReferers): Eval[Either[Exception, Parser]] =
         Eval
           .later {
             val s = Source.fromFile(filePath);
@@ -55,7 +55,7 @@ object CreateParser {
 
   implicit def idCreateParser: CreateParser[Id] =
     new CreateParser[Id] {
-      def create(filePath: String, referers: Map[String, RefererLookup]): Either[Exception, Parser] = {
+      def create(filePath: String, referers: ParsedReferers): Either[Exception, Parser] = {
         val s = Source.fromFile(filePath)
         val rawJson =
           try s.mkString
@@ -68,9 +68,21 @@ object CreateParser {
 }
 
 class Parser private[refererparser] (
-  referersFromFile: Map[String, RefererLookup],
-  referersFromMap: Map[String, RefererLookup]
+  referersFromFile: ParsedReferers,
+  referersFromMap: ParsedReferers
 ) {
+
+  /**
+   * Classifies an injected `utm_source` query parameter value (e.g. "chatgpt.com") against the
+   * referer database's `utm_sources` entries. Unlike the `parse` methods, this does not look at the
+   * referer URI: some sites inject `utm_source` in place of (or in addition to) a Referer header.
+   * Returns `None` when the value is not recognised. The `term` is always `None` for now.
+   */
+  def parseUtmSource(utmSource: String): Option[ExternalReferer] =
+    referersFromMap.byUtmSource
+      .get(utmSource)
+      .orElse(referersFromFile.byUtmSource.get(utmSource))
+      .map(lookup => ExternalReferer(lookup.medium, lookup.source, None))
 
   private def toUri(uri: String): Option[URI] =
     if (uri == "")
@@ -155,14 +167,14 @@ class Parser private[refererparser] (
     val resultsFromMap: LazyList[RefererLookup] = for {
       path <- paths
       host <- hosts
-      result <- referersFromMap.get(host + path).to(LazyList)
+      result <- referersFromMap.byDomain.get(host + path).to(LazyList)
     } yield result
 
     resultsFromMap.headOption.orElse {
       val results: LazyList[RefererLookup] = for {
         path <- paths
         host <- hosts
-        result <- referersFromFile.get(host + path).to(LazyList)
+        result <- referersFromFile.byDomain.get(host + path).to(LazyList)
       } yield result
 
       results.headOption
@@ -195,5 +207,8 @@ class Parser private[refererparser] (
 
 object Parser {
   def fromMap(referers: Map[String, RefererLookup]): Parser =
-    new Parser(Map.empty, referers)
+    new Parser(ParsedReferers.empty, ParsedReferers.fromDomainMap(referers))
+
+  def fromReferers(referers: ParsedReferers): Parser =
+    new Parser(ParsedReferers.empty, referers)
 }

--- a/src/test/resources/referers-utm.json
+++ b/src/test/resources/referers-utm.json
@@ -1,0 +1,38 @@
+{
+  "chatbot": {
+    "ChatGPT": {
+      "domains": [
+        "chatgpt.com",
+        "chat.openai.com"
+      ],
+      "utm_sources": [
+        "chatgpt.com"
+      ]
+    },
+    "Perplexity": {
+      "domains": [
+        "perplexity.ai",
+        "www.perplexity.ai"
+      ],
+      "utm_sources": [
+        "perplexity.ai"
+      ]
+    },
+    "NoDomains": {
+      "domains": [],
+      "utm_sources": [
+        "nodomains.example"
+      ]
+    }
+  },
+  "search": {
+    "Google": {
+      "domains": [
+        "www.google.com"
+      ],
+      "parameters": [
+        "q"
+      ]
+    }
+  }
+}

--- a/src/test/scala/com/snowplowanalytics/refererparser/ReferersFromMapTest.scala
+++ b/src/test/scala/com/snowplowanalytics/refererparser/ReferersFromMapTest.scala
@@ -40,12 +40,12 @@ class ReferersFromMapTest extends Specification {
     )
 
     val ioParser = CreateParser[IO]
-      .create(resource, referers)
+      .create(resource, ParsedReferers.fromDomainMap(referers))
       .unsafeRunSync()
       .fold(throw _, identity)
 
     val evalParser = CreateParser[Eval]
-      .create(resource, referers)
+      .create(resource, ParsedReferers.fromDomainMap(referers))
       .value
       .fold(throw _, identity)
 
@@ -62,7 +62,7 @@ class ReferersFromMapTest extends Specification {
     )
 
     val ioParser = CreateParser[IO]
-      .create(resource, referers)
+      .create(resource, ParsedReferers.fromDomainMap(referers))
       .unsafeRunSync()
       .fold(throw _, identity)
 
@@ -82,7 +82,7 @@ class ReferersFromMapTest extends Specification {
     )
 
     val ioParser = CreateParser[IO]
-      .create(resource, referers)
+      .create(resource, ParsedReferers.fromDomainMap(referers))
       .unsafeRunSync()
       .fold(throw _, identity)
 

--- a/src/test/scala/com/snowplowanalytics/refererparser/UtmSourceTest.scala
+++ b/src/test/scala/com/snowplowanalytics/refererparser/UtmSourceTest.scala
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2012-present Snowplow Analytics Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.snowplowanalytics.refererparser
+
+import org.specs2.Specification
+
+class UtmSourceTest extends Specification {
+  def is = s2"""
+  parseUtmSource should
+    classify a known utm_source value into medium and source $e1
+    return None for an unknown utm_source value $e2
+    give precedence to referers from map over referers from file $e3
+    load utm_sources from the referer database JSON $e4
+    return None when no utm_sources are configured $e5
+    capture utm_sources even for an entry with no domains $e6
+  """
+
+  private val chatGPT = RefererLookup("chatbot", "ChatGPT", Nil)
+
+  def e1 = {
+    val parser = Parser.fromReferers(ParsedReferers(Map.empty, Map("chatgpt.com" -> chatGPT)))
+
+    parser.parseUtmSource("chatgpt.com") shouldEqual Some(ExternalReferer("chatbot", "ChatGPT", None))
+  }
+
+  def e2 = {
+    val parser = Parser.fromReferers(ParsedReferers(Map.empty, Map("chatgpt.com" -> chatGPT)))
+
+    parser.parseUtmSource("unknown.example.com") shouldEqual None
+  }
+
+  def e3 = {
+    // The referers-utm.json file classifies "chatgpt.com" as ChatGPT; the map overrides it
+    val resource  = getClass.getResource("/referers-utm.json").getPath
+    val overrides = ParsedReferers(Map.empty, Map("chatgpt.com" -> RefererLookup("chatbot", "Overridden", Nil)))
+    val parser    = CreateParser[cats.Id].create(resource, overrides).fold(throw _, identity)
+
+    parser.parseUtmSource("chatgpt.com") shouldEqual Some(ExternalReferer("chatbot", "Overridden", None))
+  }
+
+  def e4 = {
+    val resource = getClass.getResource("/referers-utm.json").getPath
+    val parser   = CreateParser[cats.Id].create(resource).fold(throw _, identity)
+
+    (parser.parseUtmSource("chatgpt.com") shouldEqual Some(ExternalReferer("chatbot", "ChatGPT", None))) and
+      (parser.parseUtmSource("perplexity.ai") shouldEqual Some(ExternalReferer("chatbot", "Perplexity", None)))
+  }
+
+  def e5 = {
+    // fromMap builds only a domain index, so there are no utm_source entries to match
+    val parser = Parser.fromMap(Map("www.google.com" -> RefererLookup("search", "Google", List("q"))))
+
+    parser.parseUtmSource("www.google.com") shouldEqual None
+  }
+
+  def e6 = {
+    // "NoDomains" in the fixture has an empty domains list but a utm_sources entry; because the two
+    // indexes are built independently, its utm_source is still resolvable.
+    val resource = getClass.getResource("/referers-utm.json").getPath
+    val parser   = CreateParser[cats.Id].create(resource).fold(throw _, identity)
+
+    parser.parseUtmSource("nodomains.example") shouldEqual Some(ExternalReferer("chatbot", "NoDomains", None))
+  }
+}


### PR DESCRIPTION
[PDP-2743](https://snplow.atlassian.net/browse/PDP-2743)

## Add capability to identify a referer from a `utm_source` value

### Context

Some sites — notably AI sources like ChatGPT and Perplexity — inject a `utm_source` query parameter (e.g. `utm_source=chatgpt.com`) instead of, or in addition to, setting a `Referer` header. The library today can only classify a referer from its URI/host. This PR adds the ability to classify an injected `utm_source` *value* into the same medium/source categories, so consumers (e.g. Snowplow Enrich) can attribute this traffic consistently.

### What changed

- **Referer database** gains an optional `utm_sources` key alongside `domains`/`parameters`:

  ```json
  {
    "chatbot": {
      "ChatGPT": {
        "domains": ["chatgpt.com", "chat.openai.com"],
        "utm_sources": ["chatgpt.com"]
      }
    }
  }
  ```

- **`RefererLookup`** carries a new `utmSources: List[String]` field (defaulted to `Nil`).
- **`ParseReferers`** decodes the `utm_sources` key. The auto-derived `JsonEntry` decoder is replaced with an explicit `Decoder.instance`, because `deriveDecoder` maps field names verbatim and would look for a camelCase `"utmSources"` key rather than the snake_case `"utm_sources"` used in the database.
- **`Parser`** builds a reverse index (`utm_source value -> RefererLookup`) from both the file-backed and map-backed referer entries — mirroring the existing map-over-file precedence — and exposes:

  ```scala
  def parseUtmSource(utmSource: String): Option[ExternalReferer]
  ```

  It returns the matched `medium`/`source` (with `term = None` for now), and does not consult the referer URI.

### Backward compatibility

- `utmSources` defaults to `Nil`, so the `RefererLookup` constructor stays source-compatible and existing databases without a `utm_sources` key parse unchanged (the field decodes to an empty list).
- No behaviour change to the existing `parse` methods; `parseUtmSource` is purely additive.
